### PR TITLE
Added RELAY_METHOD remove-node-consistent-hashing

### DIFF
--- a/lib/carbon/conf.py
+++ b/lib/carbon/conf.py
@@ -389,9 +389,10 @@ class CarbonRelayOptions(CarbonCacheOptions):
           self["aggregation-rules"] = join(settings["CONF_DIR"], "aggregation-rules.conf")
         settings["aggregation-rules"] = self["aggregation-rules"]
 
-        if settings["RELAY_METHOD"] not in ("rules", "consistent-hashing", "aggregated-consistent-hashing"):
+        if settings["RELAY_METHOD"] not in ("rules", "consistent-hashing", "aggregated-consistent-hashing", "remove-node-consistent-hashing"):
             print ("In carbon.conf, RELAY_METHOD must be either 'rules' or "
-                   "'consistent-hashing' or 'aggregated-consistent-hashing'. Invalid value: '%s'" %
+                   "'consistent-hashing' or 'aggregated-consistent-hashing' or "
+                   "'remove-node-consistent-hashing. Invalid value: '%s'" %
                    settings.RELAY_METHOD)
             sys.exit(1)
 

--- a/lib/carbon/routers.py
+++ b/lib/carbon/routers.py
@@ -131,15 +131,12 @@ class RemoveNodeConsistentHashingRouter(DatapointRouter):
     self.hash_router.removeDestination(destination)
 
   def getDestinations(self, key):
-    file = open("/home/xad/testing", "a")
     # Remove node from the metric
     list_nodes = key.split(".")
     num_nodes = len(list_nodes)    
     skip_node_index = (self.skip_node + num_nodes) % num_nodes
     list_nodes.pop(skip_node_index)
     resolved_metric = ".".join(list_nodes)
-
-    file.write("[SNCHR] key: " + str(key) + ", resolved_metric: " + str(resolved_metric) + "\n")
 
     destinations = set()
     for destination in self.hash_router.getDestinations(resolved_metric):
@@ -148,4 +145,3 @@ class RemoveNodeConsistentHashingRouter(DatapointRouter):
     for destination in destinations:
       file.write("destination: " + str(destination) + "\n")
       yield destination
-    file.close() 

--- a/lib/carbon/routers.py
+++ b/lib/carbon/routers.py
@@ -143,5 +143,4 @@ class RemoveNodeConsistentHashingRouter(DatapointRouter):
       destinations.add(destination)
 
     for destination in destinations:
-      file.write("destination: " + str(destination) + "\n")
       yield destination

--- a/lib/carbon/routers.py
+++ b/lib/carbon/routers.py
@@ -118,3 +118,34 @@ class AggregatedConsistentHashingRouter(DatapointRouter):
 
     for destination in destinations:
       yield destination
+
+class RemoveNodeConsistentHashingRouter(DatapointRouter):
+  def __init__(self, replication_factor=1, skip_node=0):
+    self.hash_router = ConsistentHashingRouter(replication_factor)
+    self.skip_node = skip_node
+
+  def addDestination(self, destination):
+    self.hash_router.addDestination(destination)
+
+  def removeDestination(self, destination):
+    self.hash_router.removeDestination(destination)
+
+  def getDestinations(self, key):
+    file = open("/home/xad/testing", "a")
+    # Remove node from the metric
+    list_nodes = key.split(".")
+    num_nodes = len(list_nodes)    
+    skip_node_index = (self.skip_node + num_nodes) % num_nodes
+    list_nodes.pop(skip_node_index)
+    resolved_metric = ".".join(list_nodes)
+
+    file.write("[SNCHR] key: " + str(key) + ", resolved_metric: " + str(resolved_metric) + "\n")
+
+    destinations = set()
+    for destination in self.hash_router.getDestinations(resolved_metric):
+      destinations.add(destination)
+
+    for destination in destinations:
+      file.write("destination: " + str(destination) + "\n")
+      yield destination
+    file.close() 

--- a/lib/carbon/routers.py
+++ b/lib/carbon/routers.py
@@ -120,9 +120,9 @@ class AggregatedConsistentHashingRouter(DatapointRouter):
       yield destination
 
 class RemoveNodeConsistentHashingRouter(DatapointRouter):
-  def __init__(self, replication_factor=1, skip_node=0):
+  def __init__(self, replication_factor=1, remove_node=0):
     self.hash_router = ConsistentHashingRouter(replication_factor)
-    self.skip_node = skip_node
+    self.remove_node = remove_node
 
   def addDestination(self, destination):
     self.hash_router.addDestination(destination)
@@ -134,8 +134,8 @@ class RemoveNodeConsistentHashingRouter(DatapointRouter):
     # Remove node from the metric
     list_nodes = key.split(".")
     num_nodes = len(list_nodes)    
-    skip_node_index = (self.skip_node + num_nodes) % num_nodes
-    list_nodes.pop(skip_node_index)
+    remove_node_index = (self.remove_node + num_nodes) % num_nodes
+    list_nodes.pop(remove_node_index)
     resolved_metric = ".".join(list_nodes)
 
     destinations = set()

--- a/lib/carbon/service.py
+++ b/lib/carbon/service.py
@@ -170,7 +170,7 @@ def createAggregatorService(config):
 
 
 def createRelayService(config):
-    from carbon.routers import RelayRulesRouter, ConsistentHashingRouter, AggregatedConsistentHashingRouter
+    from carbon.routers import RelayRulesRouter, ConsistentHashingRouter, AggregatedConsistentHashingRouter, RemoveNodeConsistentHashingRouter
     from carbon.client import CarbonClientManager
     from carbon.conf import settings
     from carbon import events
@@ -186,6 +186,8 @@ def createRelayService(config):
       from carbon.aggregator.rules import RuleManager
       RuleManager.read_from(settings["aggregation-rules"])
       router = AggregatedConsistentHashingRouter(RuleManager, settings.REPLICATION_FACTOR)
+    elif settings.RELAY_METHOD == 'remove-node-consistent-hashing':
+      router = RemoveNodeConsistentHashingRouter(settings.REPLICATION_FACTOR, settings.SKIP_NODE)
 
     client_manager = CarbonClientManager(router)
     client_manager.setServiceParent(root_service)

--- a/lib/carbon/service.py
+++ b/lib/carbon/service.py
@@ -187,7 +187,7 @@ def createRelayService(config):
       RuleManager.read_from(settings["aggregation-rules"])
       router = AggregatedConsistentHashingRouter(RuleManager, settings.REPLICATION_FACTOR)
     elif settings.RELAY_METHOD == 'remove-node-consistent-hashing':
-      router = RemoveNodeConsistentHashingRouter(settings.REPLICATION_FACTOR, settings.SKIP_NODE)
+      router = RemoveNodeConsistentHashingRouter(settings.REPLICATION_FACTOR, settings.REMOVE_NODE)
 
     client_manager = CarbonClientManager(router)
     client_manager.setServiceParent(root_service)


### PR DESCRIPTION
This change adds a new relay rule which determines the destination of the metric by first removing a particular node.
In carbon.conf: 
RELAY_METHOD = remove-node-consistent-hashing

//Removes last node of metric
REMOVE_NODE = -1 
